### PR TITLE
`gRPC` client

### DIFF
--- a/memcrab/README.md
+++ b/memcrab/README.md
@@ -1,0 +1,1 @@
+# memcrab

--- a/memcrab/src/lib.rs
+++ b/memcrab/src/lib.rs
@@ -1,2 +1,6 @@
+#[allow(clippy::all)]
+#[rustfmt::skip]
+mod pb;
+
 #[cfg(test)]
 mod tests {}

--- a/memcrab/src/lib.rs
+++ b/memcrab/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::all)]
 #[rustfmt::skip]
-mod pb;
+pub mod pb;
 
 #[cfg(test)]
 mod tests {}

--- a/memcrab/src/pb.rs
+++ b/memcrab/src/pb.rs
@@ -1,0 +1,148 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRequest {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetResponse {
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetRequest {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetResponse {}
+/// Generated client implementations.
+pub mod cache_rpc_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct CacheRpcClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CacheRpcClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CacheRpcClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CacheRpcClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            CacheRpcClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn get(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cache_grpc.CacheRPC/Get");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("cache_grpc.CacheRPC", "Get"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn set(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetRequest>,
+        ) -> std::result::Result<tonic::Response<super::SetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cache_grpc.CacheRPC/Set");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("cache_grpc.CacheRPC", "Set"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}

--- a/memcrab/tests/run.rs
+++ b/memcrab/tests/run.rs
@@ -1,16 +1,6 @@
-# memcrab
-
-`memcrab` client.
-
-## Examples
-
-### gRPC
-
-```rust
 use memcrab::pb::{cache_rpc_client::CacheRpcClient, GetRequest, SetRequest};
 
-#[tokio::main]
-async fn main() {
+async fn _test_client() {
     let dst_addr = "http://[::1]:50051";
     let mut client = CacheRpcClient::connect(dst_addr).await.unwrap();
 
@@ -23,10 +13,10 @@ async fn main() {
     match resp.value {
         Some(val) => {
             println!("got bytes from cache: {:?}", val);
-        },
+        }
         None => {
             println!("no value in cache");
-        },
+        }
     }
 
     let msg = SetRequest {
@@ -36,4 +26,3 @@ async fn main() {
     let req = tonic::Request::new(msg);
     client.set(req).await.unwrap();
 }
-```


### PR DESCRIPTION
Currently only contains proto generated code (tonic client). Cache values are just bytes.